### PR TITLE
This PR shows a way to get runtime tests for .MuxWith

### DIFF
--- a/pkg/tests/mux_with_test.go
+++ b/pkg/tests/mux_with_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+func todo[T any]() T { panic("TODO") }
+
+func TestMuxWithProvider(t *testing.T) {
+	ctx := context.Background()
+
+	prov := todo[tfbridge.ProviderInfo]()
+	pulumiSchema := todo[[]byte]()
+	grpcTestCase := todo[string]()
+
+	server := tfbridge.NewProvider(ctx, nil, prov.Name, "1.0.0", prov.P, prov, pulumiSchema)
+
+	testutils.Replay(t, server, grpcTestCase)
+}

--- a/pkg/tests/regress_1020_test.go
+++ b/pkg/tests/regress_1020_test.go
@@ -16,11 +16,12 @@ package tests
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"net"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	testutils "github.com/pulumi/pulumi-terraform-bridge/testing/x"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -140,7 +141,7 @@ func TestRegress1020(t *testing.T) {
 		},
 	}
 
-	server := func(p shim.Provider) *tfbridge.Provider {
+	server := func(p shim.Provider) pulumirpc.ResourceProviderServer {
 		info := tfbridge.ProviderInfo{
 			P:           p,
 			Name:        "aws",

--- a/pkg/tfbridge/serve.go
+++ b/pkg/tfbridge/serve.go
@@ -16,48 +16,16 @@ package tfbridge
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
-	"github.com/pulumi/pulumi-terraform-bridge/x/muxer"
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Serve fires up a Pulumi resource provider listening to inbound gRPC traffic,
 // and translates calls from Pulumi into actions against the provided Terraform Provider.
-func Serve(module string, version string, info ProviderInfo, pulumiSchema []byte) error {
+func Serve(module, version string, info ProviderInfo, pulumiSchema []byte) error {
 	// Create a new resource provider server and listen for and serve incoming connections.
 	return provider.Main(module, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		if len(info.MuxWith) > 0 {
-			// If we have multiple providers to serve, Mux them together.
-
-			var mapping muxer.DispatchTable
-			if m, found, err := metadata.Get[muxer.DispatchTable](info.GetMetadata(), "mux"); err != nil {
-				return nil, err
-			} else if found {
-				mapping = m
-			} else {
-				return nil, fmt.Errorf("missing pre-computed muxer mapping")
-			}
-
-			servers := []muxer.Endpoint{{
-				Server: func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-					return NewProvider(context.Background(), host, module, version, info.P, info, pulumiSchema), nil
-				},
-			}}
-			for _, f := range info.MuxWith {
-				servers = append(servers, muxer.Endpoint{Server: f.GetInstance})
-			}
-
-			return muxer.Main{
-				Schema:        pulumiSchema,
-				DispatchTable: mapping,
-				Servers:       servers,
-			}.Server(host, module, version)
-		}
-
-		// Create a new bridge provider.
 		return NewProvider(context.TODO(), host, module, version, info.P, info, pulumiSchema), nil
 	})
 }


### PR DESCRIPTION
This PR shows a way to get runtime testability of a muxed provider by leveraging replay testing.

This does introduce a breaking change to `tfbridge.NewProvider`, changing its return type from `*Provider` to `pulumirpc.ResourceProviderServer`. My suspicion is that this won't be a problem in practice, since `*Provider` has no public methods except those that are part of `pulumirpc.ResourceProviderServer`.